### PR TITLE
Test over Django 1.{10,11} and Python 36.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,2 @@
 coverage
+django_nose

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
-    py{27,33,34,py}-django17
-    py{27,33,34,35,py}-django18
-    py{27,34,35,py}-django19
+    py{27,33,34,35,36,py}-django18
+    py{27,34,35,36,py}-django19
+    py{27,34,35,36,py}-django110
+    py{27,34,35,36,py}-django111
 
 [testenv]
 sitepackages = False
@@ -12,7 +13,8 @@ setenv = C_DEBUG_TEST = 1
          PIP_DOWNLOAD_CACHE=~/.pip-cache
 deps =
     -r{toxinidir}/requirements/default.txt
+    django111: Django~=1.11.0
+    django110: Django~=1.10.0
     django19: Django==1.9
     django18: Django==1.8.5
-    django17: Django==1.7.9
-    py{27,33,34,35,py}: -r{toxinidir}/requirements/test.txt
+    py{27,33,34,35,36,py}: -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
Django 1.11 is the new LTS. Dropped pre-1.8 (last LTS) Django versions.

And added Python 3.6 to the tox test matrix